### PR TITLE
Dataset Check before operation

### DIFF
--- a/test.py
+++ b/test.py
@@ -28,8 +28,14 @@ def Testing():
     #########################################################################
     ## Get dataset
     #########################################################################
-    print("Get dataset")
-    loader = Generator()
+    
+    print("Check mode for dataset")
+    #skip dataset loading if will be tested on special image or video
+    if(p.mode not in [1,2]):
+        loader = Generator()
+        print("Dataset loaded")
+    else:
+        print("Skipped loading dataset")
 
     ##############################
     ## Get agent and model


### PR DESCRIPTION
Noticed that running the model on the given image or video doesn't require dataset check. 

For testing with the trained weights:  check p.mode to avoid unnecessary tusimple check.